### PR TITLE
Adding Get FlashPlayer from Archive script and fixing .travis.yml for OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ bin-release/
 # Project files, i.e. `.project`, `.actionScriptProperties` and `.flexProperties`
 # should NOT be excluded as they contain compiler settings and other important
 # information for Eclipse / Flash Builder.
+
+# Downloaded Flash Player used by Travis-CI
+Flash Player Debugger.app

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
-language: objective-c
+language: java
+jdk:
+  - openjdk6
 before_script:
-  - curl 'http://fpdownload.macromedia.com/pub/flashplayer/updaters/11/flashplayer_11_sa_debug.app.zip' >> flashplayer.zip
-  - unzip flashplayer.zip
+  # To pick a specific Flash Player from the Adobe Archives:
+  # http://helpx.adobe.com/flash-player/kb/archived-flash-player-versions.html
+  # getFpFromArchive script will download and unzip the needed Flash Player
+  - sh getFpFromArchive 'http://fpdownload.macromedia.com/pub/flashplayer/installers/archive/fp_10.3.183.90_archive_mac_only.zip'
 script: mvn test -DflashPlayer.command=Flash\ Player\ Debugger.app/Contents/MacOS/Flash\ Player\ Debugger

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ before_script:
   # To pick a specific Flash Player from the Adobe Archives:
   # http://helpx.adobe.com/flash-player/kb/archived-flash-player-versions.html
   # getFpFromArchive script will download and unzip the needed Flash Player
-  - sh getFpFromArchive 'http://fpdownload.macromedia.com/pub/flashplayer/installers/archive/fp_10.3.183.90_archive_mac_only.zip'
+  - sh getFpFromArchive 'http://download.macromedia.com/pub/flashplayer/installers/archive/fp_11.7.700.225_archive.zip'
 script: mvn test -DflashPlayer.command=Flash\ Player\ Debugger.app/Contents/MacOS/Flash\ Player\ Debugger

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
-language: java
-jdk:
-  - openjdk6
+language: objective-c
+
 before_script:
-  # To pick a specific Flash Player from the Adobe Archives:
+  # set the JAVA_HOME which is not set by default for OSX Travis-CI workers
+  - export "JAVA_HOME=`/usr/libexec/java_home`"
+  # Download and install a specific Flash Player from the Adobe Archives:
   # http://helpx.adobe.com/flash-player/kb/archived-flash-player-versions.html
-  # getFpFromArchive script will download and unzip the needed Flash Player
   - sh getFpFromArchive 'http://download.macromedia.com/pub/flashplayer/installers/archive/fp_11.7.700.225_archive.zip'
+
 script: mvn test -DflashPlayer.command=Flash\ Player\ Debugger.app/Contents/MacOS/Flash\ Player\ Debugger

--- a/getFpFromArchive
+++ b/getFpFromArchive
@@ -33,7 +33,7 @@
 #
 
 FP_ARCHIVE_PATH="fp_archive"
-FP_ARCHILVE_ZIP="fp_archive.zip"
+FP_ARCHIVE_ZIP="fp_archive.zip"
 EXPECTED_ARG="<FlashPlayer Archile Url>"
 VERSION="1.0"
 
@@ -50,26 +50,39 @@ if [ "$1" = "" ]; then
 fi
 
 echo "[INFO] ------------------------------------------------------------------------"
-echo "[INFO] Getting FlashPlayer From Archive ${VERSION}"
+echo "[INFO] Get FlashPlayer From Archive, ${VERSION}"
 echo "[INFO] ------------------------------------------------------------------------"
 
-FP_ZIP_ARCHIVE_URL=$1
-
 # Download the archive
-curl ${FP_ZIP_ARCHIVE_URL} >> ${FP_ARCHILVE_ZIP}
+FP_ZIP_ARCHIVE_URL=$1
+echo "[INFO] Downloading: ${FP_ZIP_ARCHIVE_URL}"
+curl ${FP_ZIP_ARCHIVE_URL} >> ${FP_ARCHIVE_ZIP}
+
 # Unzip archive
-unzip fp_archive -d ${FP_ARCHIVE_PATH}
+echo "[INFO] Unzipping to: ${FP_ARCHIVE_PATH}"
+unzip ${FP_ARCHIVE_ZIP} -d ${FP_ARCHIVE_PATH}
+
 # locate the mac_sa_debug.app.zip file and ignore any .* files
-MAC_SA_DEBUG_APP_ZIP=`find . -type f \( -iname "*mac_sa_debug.app.zip" ! -iname ".*" \)`
+# these seem to be inconsistent, "*mac_sa_debug.app.zip" and
+# "*mac_sa_debug.zip" have been notedr,
+MAC_SA_DEBUG_APP_ZIP=`find . -type f \( -iname "*mac_sa_debug*.zip" ! -iname ".*" \)`
+if [ "${MAC_SA_DEBUG_APP_ZIP}" = "" ]; then
+	echo "[ERROR] Can not find required Mac SA Debug Player ZIP."
+	exit 1
+fi
+echo "[INFO] Found Mac SA Debug Player Zip: ${MAC_SA_DEBUG_APP_ZIP}"
+
 # Unzip mac_sa_debug.app.zip
+echo "[INFO] Unzipping player"
 unzip ${MAC_SA_DEBUG_APP_ZIP}
 
 # cleanup
-rm ${FP_ARCHILVE_ZIP}
+echo "[INFO] cleaning up temp files."
+rm ${FP_ARCHIVE_ZIP}
 rm -r ${FP_ARCHIVE_PATH}
 
 echo "[INFO] ------------------------------------------------------------------------"
-echo "[INFO] Flash Player Downloaded Complete."
+echo "[INFO] Flash Player Downloaded and Unzip Success"
 echo "[INFO] ------------------------------------------------------------------------"
 
 # done

--- a/getFpFromArchive
+++ b/getFpFromArchive
@@ -2,8 +2,12 @@
 #
 # Get FlashPlayer Form Archive 1.0, 2014
 #
-# Script downloads a Flash Archive zip and looks for the Mac Debug Player.
-# It will then unzip it to the expected location and cleanup what was downloaded
+# Script downloads a Flash Archive zip, unzips the archive, located the needed
+# Mac OS Debug Flash Player, unzips that file and cleans up all but the Flash
+# Player folder.
+#
+# Find specific Flash Player from the Adobe Archives:
+# http://helpx.adobe.com/flash-player/kb/archived-flash-player-versions.html
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of 
 # this software and associated documentation files (the "Software"), to deal in 
@@ -31,6 +35,7 @@
 FP_ARCHIVE_PATH="fp_archive"
 FP_ARCHILVE_ZIP="fp_archive.zip"
 EXPECTED_ARG="<FlashPlayer Archile Url>"
+VERSION="1.0"
 
 if [ "$#" -gt 1 ]; then
   echo "Too many arguments."
@@ -43,6 +48,10 @@ if [ "$1" = "" ]; then
 	echo "Usage: $0 ${EXPECTED_ARG}"
 	exit 1
 fi
+
+echo "[INFO] ------------------------------------------------------------------------"
+echo "[INFO] Getting FlashPlayer From Archive ${VERSION}"
+echo "[INFO] ------------------------------------------------------------------------"
 
 FP_ZIP_ARCHIVE_URL=$1
 
@@ -58,6 +67,10 @@ unzip ${MAC_SA_DEBUG_APP_ZIP}
 # cleanup
 rm ${FP_ARCHILVE_ZIP}
 rm -r ${FP_ARCHIVE_PATH}
+
+echo "[INFO] ------------------------------------------------------------------------"
+echo "[INFO] Flash Player Downloaded Complete."
+echo "[INFO] ------------------------------------------------------------------------"
 
 # done
 exit 0

--- a/getFpFromArchive
+++ b/getFpFromArchive
@@ -1,0 +1,63 @@
+#!/bin/sh
+#
+# Get FlashPlayer Form Archive 1.0, 2014
+#
+# Script downloads a Flash Archive zip and looks for the Mac Debug Player.
+# It will then unzip it to the expected location and cleanup what was downloaded
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy of 
+# this software and associated documentation files (the "Software"), to deal in 
+# the Software without restriction, including without limitation the rights to 
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
+# of the Software, and to permit persons to whom the Software is furnished to do 
+# so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all 
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+# SOFTWARE.
+# 
+# Tested on OSX (10.9)
+# 
+# Copyright (c) 2014 Hays Clark
+#
+
+FP_ARCHIVE_PATH="fp_archive"
+FP_ARCHILVE_ZIP="fp_archive.zip"
+EXPECTED_ARG="<FlashPlayer Archile Url>"
+
+if [ "$#" -gt 1 ]; then
+  echo "Too many arguments."
+  echo "Usage: $0 ${EXPECTED_ARG}"
+  exit 1
+fi
+
+if [ "$1" = "" ]; then
+	echo "Missing required argument."
+	echo "Usage: $0 ${EXPECTED_ARG}"
+	exit 1
+fi
+
+FP_ZIP_ARCHIVE_URL=$1
+
+# Download the archive
+curl ${FP_ZIP_ARCHIVE_URL} >> ${FP_ARCHILVE_ZIP}
+# Unzip archive
+unzip fp_archive -d ${FP_ARCHIVE_PATH}
+# locate the mac_sa_debug.app.zip file and ignore any .* files
+MAC_SA_DEBUG_APP_ZIP=`find . -type f \( -iname "*mac_sa_debug.app.zip" ! -iname ".*" \)`
+# Unzip mac_sa_debug.app.zip
+unzip ${MAC_SA_DEBUG_APP_ZIP}
+
+# cleanup
+rm ${FP_ARCHILVE_ZIP}
+rm -r ${FP_ARCHIVE_PATH}
+
+# done
+exit 0


### PR DESCRIPTION
@Larusso, This pull request fixed Issue #1.  Two issues manifested over the past year.  The Adobe link that was being used to get the Flash Player became broken. I added a shell script which gets the needed player from a Adobe Flash Player archive url.  The other issue was the JAVA_HOME environment variable was not set which is the standard setup for current OSX Travis workers.  This has been fixed and commented in the .travis.yml.

Cheers,
Hays
